### PR TITLE
Add GPX parsing support for track uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # NoniPlotter
 
-### A web app for plotting GPS logging files from the NoniGpsPlot Windows Mobile program.
+### A web app for plotting GPX track files.
 
 ### Also, and mostly, an experiment to see if ChatGPT's Codex can write anything useful from scratch with no actual code-writing by the user (the answer is: yes)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "express": "^4.18.2",
-        "multer": "^1.4.5-lts.1"
+        "multer": "^1.4.5-lts.1",
+        "sax": "^1.4.1"
       }
     },
     "node_modules/accepts": {
@@ -765,6 +766,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
     },
     "node_modules/send": {
       "version": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "sax": "^1.4.1"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -18,8 +18,8 @@
       <ul id="trackList"></ul>
       <div id="trackInfo"><em>Select a track above</em></div>
       <form id="uploadForm">
-        <input type="file" name="plotfile" />
-        <button type="submit">Upload</button>
+        <input type="file" name="plotfile" accept=".gpx" />
+        <button type="submit">Upload GPX</button>
       </form>
       <div class="zoomControls">
         <button type="button" id="zoomIn">Zoom In</button>


### PR DESCRIPTION
## Summary
- swap legacy plot parser for GPX trackpoint parser
- allow uploading .gpx files from the UI
- refresh docs to mention GPX tracks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d2df2f148327810e04d6ee86f2e0