### PR TITLE
Switch to GPX tracks with resilient parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NoniPlotter
 
-### A web app for plotting GPS logging files from the NoniGpsPlot Windows Mobile program.
+### A web app for plotting GPX track files straight from your globetrotting gadgets.
 
 ### Also, and mostly, an experiment to see if ChatGPT's Codex can write anything useful from scratch with no actual code-writing by the user (the answer is: yes)


### PR DESCRIPTION
## Summary
- swap custom plot parsing for new GPX reader
- skip non-GPX files and shrug off malformed data
- tweak docs to trumpet GPX support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0d79079cc8327a1bf52015b0a63f4