### PR TITLE
chore: refresh repo on startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,6 @@ node_modules
 npm-debug.log
 Dockerfile
 docker-compose.yml
-.git
+# Include .git so the container can pull updates
 .gitignore
 plots

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:18-alpine
 WORKDIR /app
+# Grab git so we can update the repo on container start
+RUN apk add --no-cache git
 COPY package*.json ./
 RUN npm ci --omit=dev
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       pull: true
     image: noniplotter
     pull_policy: build
+    # Update the codebase before launching the server
+    command: sh -c "git pull && node server.js"
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
## Summary
- keep the repo's history inside the container so `git pull` works
- install git in the image and pull latest code before launching the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c190cda73883279af6efe32494d7b8