### PR TITLE
Add option to filter out GPX jump points

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -228,20 +228,14 @@ function filterJumps(points) {
   const maxDist = Math.max(1000, median * 10);
 
   const cleaned = [points[0]];
-  for (let i = 1; i < points.length - 1; i++) {
-    const prev = cleaned[cleaned.length - 1];
+  for (let i = 1; i < points.length; i++) {
+    const last = cleaned[cleaned.length - 1];
     const cur = points[i];
-    const next = points[i + 1];
-    const dPrev = haversine(prev, cur);
-    const dNext = haversine(cur, next);
-    const dSkip = haversine(prev, next);
-
-    if (dPrev > maxDist && dNext > maxDist && dSkip <= maxDist) {
-      continue; // yeet the out-and-back spike
+    const d = haversine(last, cur);
+    if (d <= maxDist) {
+      cleaned.push(cur);
     }
-    cleaned.push(cur);
   }
-  cleaned.push(points[points.length - 1]);
   return cleaned;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,7 @@
         <button type="button" id="zoomIn">Zoom In</button>
         <button type="button" id="zoomOut">Zoom Out</button>
       </div>
+      <label id="jumpLabel"><input type="checkbox" id="jumpFilter" /> Remove jumps</label>
       <button type="button" id="downloadBtn">Download Selected</button>
       <button type="button" id="themeToggle">Toggle Theme</button>
     </aside>

--- a/public/styles.css
+++ b/public/styles.css
@@ -152,6 +152,11 @@ main {
   margin-top: 1rem;
 }
 
+#jumpLabel {
+  display: block;
+  margin-top: 0.5rem;
+}
+
 @media (max-width: 600px) {
   #menuToggle {
     display: block;


### PR DESCRIPTION
## Summary
- Add sidebar checkbox to strip out GPS jumps in plotted tracks
- Filter out-of-bounds points (>1km jumps) and recompute track stats

## Testing
- `node --check public/app.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1934c30c88327b3a079abf2ddd1fa