### PR TITLE
Add retro-friendly upload page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
         <input type="file" name="plotfile" />
         <button type="submit">Upload</button>
       </form>
+      <p class="legacyLink"><a href="/retro-upload.html">Need a no-JavaScript uploader?</a></p>
       <div class="zoomControls">
         <button type="button" id="zoomIn">Zoom In</button>
         <button type="button" id="zoomOut">Zoom Out</button>

--- a/public/retro-upload.html
+++ b/public/retro-upload.html
@@ -9,42 +9,45 @@
     body {
       margin: 0;
       padding: 0;
-      color: #222;
+      color: #1f1f1f;
       font-family: "Trebuchet MS", Arial, sans-serif;
-      font-size: 18px;
+      font-size: 16px;
+      line-height: 1.45;
     }
     .wrap {
-      max-width: 26em;
+      max-width: 24em;
       margin: 0 auto;
-      padding: 1.4em 1.2em 2em;
+      padding: 1.1em 1.1em 1.6em;
     }
-    h1 { font-size: 1.55em; margin: 0 0 0.6em 0; }
-    p { line-height: 1.5; margin: 0.6em 0; }
+    h1 { font-size: 1.35em; margin: 0 0 0.5em 0; color: #2f6a4e; }
+    p { margin: 0.55em 0; }
     form {
-      border: 1px solid #555;
-      background: #fff;
-      padding: 1em 1.1em 1.2em;
-      margin-top: 1.2em;
+      border: 1px solid #67624d;
+      background: #fffdf6;
+      padding: 0.85em 0.95em 1em;
+      margin-top: 1em;
     }
-    label { display: block; margin-bottom: 1em; }
-    .label-text { display: block; margin-bottom: 0.35em; font-weight: bold; }
+    label { display: block; margin-bottom: 0.85em; }
+    .label-text { display: block; margin-bottom: 0.3em; font-weight: bold; font-size: 0.95em; }
     input[type="file"], input[type="password"] {
       width: 100%;
-      font-size: 1em;
-      padding: 0.5em;
-      border: 1px solid #777;
+      font-size: 0.95em;
+      padding: 0.45em;
+      border: 1px solid #8b8875;
+      background: #fffefb;
     }
     input[type="submit"] {
       width: 100%;
-      margin-top: 0.4em;
-      padding: 0.65em;
-      font-size: 1em;
+      margin-top: 0.35em;
+      padding: 0.55em;
+      font-size: 0.95em;
       background: #2f6a4e;
       color: #fff;
       border: 0;
+      letter-spacing: 0.02em;
     }
-    .note { font-size: 0.9em; color: #444; margin-top: 1.2em; }
-    .back-link { margin-top: 1.8em; }
+    .note { font-size: 0.85em; color: #494738; margin-top: 1em; }
+    .back-link { margin-top: 1.4em; font-size: 0.85em; }
     .back-link a { color: #2f6a4e; }
   </style>
 </head>

--- a/public/retro-upload.html
+++ b/public/retro-upload.html
@@ -2,33 +2,74 @@
 <html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>NoniPlotter Retro Upload</title>
   <style type="text/css">
-    body { background: #f5f2e8; color: #222; font-family: "Trebuchet MS", Arial, sans-serif; margin: 1.5em; }
-    h1 { font-size: 1.6em; margin-bottom: 0.5em; }
-    p { line-height: 1.4; }
-    form { border: 1px solid #555; background: #fff; padding: 1em; max-width: 32em; }
-    label { display: block; margin-bottom: 0.75em; }
-    input[type="file"], input[type="password"], input[type="text"] { width: 100%; }
-    .note { font-size: 0.9em; color: #444; margin-top: 1em; }
-    .back-link { margin-top: 1.5em; }
+    html { background: #f5f2e8; }
+    body {
+      margin: 0;
+      padding: 0;
+      color: #222;
+      font-family: "Trebuchet MS", Arial, sans-serif;
+      font-size: 18px;
+    }
+    .wrap {
+      max-width: 26em;
+      margin: 0 auto;
+      padding: 1.4em 1.2em 2em;
+    }
+    h1 { font-size: 1.55em; margin: 0 0 0.6em 0; }
+    p { line-height: 1.5; margin: 0.6em 0; }
+    form {
+      border: 1px solid #555;
+      background: #fff;
+      padding: 1em 1.1em 1.2em;
+      margin-top: 1.2em;
+    }
+    label { display: block; margin-bottom: 1em; }
+    .label-text { display: block; margin-bottom: 0.35em; font-weight: bold; }
+    input[type="file"], input[type="password"] {
+      width: 100%;
+      font-size: 1em;
+      padding: 0.5em;
+      border: 1px solid #777;
+    }
+    input[type="submit"] {
+      width: 100%;
+      margin-top: 0.4em;
+      padding: 0.65em;
+      font-size: 1em;
+      background: #2f6a4e;
+      color: #fff;
+      border: 0;
+    }
+    .note { font-size: 0.9em; color: #444; margin-top: 1.2em; }
+    .back-link { margin-top: 1.8em; }
+    .back-link a { color: #2f6a4e; }
   </style>
 </head>
 <body>
-  <h1>Retro Uploader</h1>
-  <p>This no-fuss page speaks fluent HTML 4 so the elders of the browser realm can still feed GPX tracks to NoniPlotter.</p>
-  <form action="/retro-upload" method="post" enctype="multipart/form-data">
-    <label>
-      Admin password:<br />
-      <input type="password" name="password" />
-    </label>
-    <label>
-      GPX file:<br />
-      <input type="file" name="plotfile" />
-    </label>
-    <input type="submit" value="Send File" />
-  </form>
-  <p class="note">Files march straight into the shared <code>plots</code> directory, just like the jazzy modern uploader.</p>
-  <p class="back-link"><a href="/">Return to the modern interface</a></p>
+  <div class="wrap">
+    <h1>Retro Uploader</h1>
+    <p>
+      This no-fuss page speaks fluent HTML 4 so the elders of the browser realm can still feed GPX
+      tracks to NoniPlotter.
+    </p>
+    <form action="/retro-upload" method="post" enctype="multipart/form-data">
+      <label>
+        <span class="label-text">Admin password</span>
+        <input type="password" name="password" />
+      </label>
+      <label>
+        <span class="label-text">GPX file</span>
+        <input type="file" name="plotfile" />
+      </label>
+      <input type="submit" value="Send file" />
+    </form>
+    <p class="note">
+      Files march straight into the shared <code>plots</code> directory, just like the jazzy modern uploader.
+    </p>
+    <p class="back-link"><a href="/">Return to the modern interface</a></p>
+  </div>
 </body>
 </html>

--- a/public/retro-upload.html
+++ b/public/retro-upload.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>NoniPlotter Retro Upload</title>
+  <style type="text/css">
+    body { background: #f5f2e8; color: #222; font-family: "Trebuchet MS", Arial, sans-serif; margin: 1.5em; }
+    h1 { font-size: 1.6em; margin-bottom: 0.5em; }
+    p { line-height: 1.4; }
+    form { border: 1px solid #555; background: #fff; padding: 1em; max-width: 32em; }
+    label { display: block; margin-bottom: 0.75em; }
+    input[type="file"], input[type="password"], input[type="text"] { width: 100%; }
+    .note { font-size: 0.9em; color: #444; margin-top: 1em; }
+    .back-link { margin-top: 1.5em; }
+  </style>
+</head>
+<body>
+  <h1>Retro Uploader</h1>
+  <p>This no-fuss page speaks fluent HTML 4 so the elders of the browser realm can still feed GPX tracks to NoniPlotter.</p>
+  <form action="/retro-upload" method="post" enctype="multipart/form-data">
+    <label>
+      Admin password:<br />
+      <input type="password" name="password" />
+    </label>
+    <label>
+      GPX file:<br />
+      <input type="file" name="plotfile" />
+    </label>
+    <input type="submit" value="Send File" />
+  </form>
+  <p class="note">Files march straight into the shared <code>plots</code> directory, just like the jazzy modern uploader.</p>
+  <p class="back-link"><a href="/">Return to the modern interface</a></p>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -147,6 +147,15 @@ main {
   padding: 0.25rem 0.5rem;
 }
 
+#sidebar .legacyLink {
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
+}
+
+#sidebar .legacyLink a {
+  color: var(--fg);
+}
+
 #sidebar .infoBtn {
   width: auto;
   margin-left: 0.5rem;

--- a/server.js
+++ b/server.js
@@ -44,8 +44,9 @@ function escapeHtml(str) {
 }
 
 function renderLegacyPage({ title, heading, message, status }) {
-  const pageTitle = title || heading || 'NoniPlotter';
-  const color = status === 'error' ? '#8b0000' : '#064600';
+  const pageTitle = escapeHtml(title || heading || 'NoniPlotter');
+  const safeHeading = escapeHtml(heading || 'NoniPlotter');
+  const accent = status === 'error' ? '#8b2b2b' : '#2f6a4e';
   return [
     '<!DOCTYPE html>',
     '<html>',
@@ -53,20 +54,25 @@ function renderLegacyPage({ title, heading, message, status }) {
     '  <meta charset="utf-8" />',
     `  <title>${pageTitle}</title>`,
     '  <style type="text/css">',
-    '    body { background: #fdf9f2; color: #1a1a1a; font-family: Arial, Helvetica, sans-serif; margin: 2em; }',
-    '    .panel { border: 1px solid #444; padding: 1em; max-width: 32em; background: #fff; }',
-    '    h1 { font-size: 1.4em; color: ' + color + '; margin-top: 0; }',
-    '    p { line-height: 1.4; }',
-    '    .links { margin-top: 1.5em; }',
+    '    html { background: #f5f2e8; }',
+    '    body { margin: 0; padding: 0; color: #1f1f1f; font-family: "Trebuchet MS", Arial, sans-serif; font-size: 16px; line-height: 1.45; }',
+    '    .wrap { max-width: 24em; margin: 0 auto; padding: 1.1em 1.1em 1.6em; }',
+    '    .panel { border: 1px solid #67624d; background: #fffdf6; padding: 0.9em 1em 1em; }',
+    '    h1 { font-size: 1.35em; margin: 0 0 0.5em 0; color: ' + accent + '; }',
+    '    p { margin: 0.55em 0; }',
+    '    .links { margin-top: 1em; font-size: 0.85em; }',
+    '    .links a { color: #2f6a4e; }',
     '  </style>',
     '</head>',
     '<body>',
-    '  <div class="panel">',
-    `    <h1>${heading}</h1>`,
-    `    <p>${message}</p>`,
-    '    <div class="links">',
-    '      <p><a href="/retro-upload.html">Return to the retro upload form</a></p>',
-    '      <p><a href="/">Back to the fancy map</a></p>',
+    '  <div class="wrap">',
+    '    <div class="panel">',
+    `      <h1>${safeHeading}</h1>`,
+    `      <p>${message}</p>`,
+    '      <div class="links">',
+    '        <p><a href="/retro-upload.html">Return to the retro upload form</a></p>',
+    '        <p><a href="/">Back to the fancy map</a></p>',
+    '      </div>',
     '    </div>',
     '  </div>',
     '</body>',


### PR DESCRIPTION
## Summary
- add a retro upload HTML page that works without JavaScript and links it from the sidebar
- extend the server with a password-protected `/retro-upload` endpoint that returns friendly HTML responses
- tweak sidebar styles so the legacy upload hint fits in with the existing UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccac72e94883279f209d872d8caaf8